### PR TITLE
fix: localStorageからタスク読み込み時のDate復元処理を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,12 @@ function App() {
   useEffect(() => {
     const savedTasks = localStorage.getItem('tasks')
     if (savedTasks) {
-      setTasks(JSON.parse(savedTasks))
+      const parsedTasks = JSON.parse(savedTasks)
+      const tasksWithDates = parsedTasks.map((task: any) => ({
+        ...task,
+        createdAt: new Date(task.createdAt)
+      }))
+      setTasks(tasksWithDates)
     }
   }, [])
 


### PR DESCRIPTION
## 概要
ブラウザリロード時にタスクが消える問題を修正しました。

## 変更内容
- localStorageからタスクを読み込む際のDateオブジェクト復元処理を修正
- JSON.parseで文字列になったcreatedAtフィールドを適切にDateオブジェクトに変換

Fixes #5

Generated with [Claude Code](https://claude.ai/code)