### PR TITLE
fix: prevent race condition causing tasks to disappear on reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 
 interface Task {
   id: string
@@ -9,7 +9,7 @@ interface Task {
 function App() {
   const [tasks, setTasks] = useState<Task[]>([])
   const [newTask, setNewTask] = useState('')
-  const hasLoadedInitialTasks = useRef(false)
+  const [isInitialized, setIsInitialized] = useState(false)
 
   useEffect(() => {
     const savedTasks = localStorage.getItem('tasks')
@@ -21,14 +21,14 @@ function App() {
       }))
       setTasks(tasksWithDates)
     }
-    hasLoadedInitialTasks.current = true
+    setIsInitialized(true)
   }, [])
 
   useEffect(() => {
-    if (hasLoadedInitialTasks.current) {
+    if (isInitialized) {
       localStorage.setItem('tasks', JSON.stringify(tasks))
     }
-  }, [tasks])
+  }, [tasks, isInitialized])
 
   const addTask = () => {
     if (newTask.trim()) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 interface Task {
   id: string
@@ -9,6 +9,7 @@ interface Task {
 function App() {
   const [tasks, setTasks] = useState<Task[]>([])
   const [newTask, setNewTask] = useState('')
+  const hasLoadedInitialTasks = useRef(false)
 
   useEffect(() => {
     const savedTasks = localStorage.getItem('tasks')
@@ -20,10 +21,13 @@ function App() {
       }))
       setTasks(tasksWithDates)
     }
+    hasLoadedInitialTasks.current = true
   }, [])
 
   useEffect(() => {
-    localStorage.setItem('tasks', JSON.stringify(tasks))
+    if (hasLoadedInitialTasks.current) {
+      localStorage.setItem('tasks', JSON.stringify(tasks))
+    }
   }, [tasks])
 
   const addTask = () => {


### PR DESCRIPTION
Fixed race condition where save effect would run before load effect, clearing localStorage before saved tasks could be restored.

Added hasLoadedInitialTasks ref to track when initial loading is complete and only save to localStorage after initial load is finished.

Fixes #8

Generated with [Claude Code](https://claude.ai/code)